### PR TITLE
Main checksum file is not being updated properly

### DIFF
--- a/src/main/groovy/com/scrain/gradle/ChecksumTask.groovy
+++ b/src/main/groovy/com/scrain/gradle/ChecksumTask.groovy
@@ -83,7 +83,7 @@ class ChecksumTask extends SourceTask {
         }
         String checksum = ant.properties[totalProp]
 
-        checksumFile << checksum
+        checksumFile.text = checksum
 
         logger.lifecycle ":${name} result: ${checksum}"
     }

--- a/src/test/groovy/com/scrain/gradle/ChecksumTaskSpec.groovy
+++ b/src/test/groovy/com/scrain/gradle/ChecksumTaskSpec.groovy
@@ -98,6 +98,23 @@ class ChecksumTaskSpec extends Specification {
             firstChecksum != secondChecksum
     }
 
+    def "Calculation of the checksum twice should yield the same result"() {
+        when: 'A checksum is produced'
+        File sourceFile = createFile("${project.projectDir}/foo.txt")
+        checksumTask.source = project.file(sourceFile)
+        checksumTask.compute()
+        String firstChecksum = checksumTask.checksumFile.text
+
+        and: 'Source file is renamed and the checksum recomputed'
+        sourceFile = createFile("${project.projectDir}/foo.txt")
+        checksumTask.source = project.file(sourceFile)
+        checksumTask.compute()
+        String secondChecksum = checksumTask.checksumFile.text
+
+        then: 'The checksums should be different'
+        firstChecksum == secondChecksum
+    }
+
     @Unroll
     def "checksumTask's source is configuration driven"() {
         when:


### PR DESCRIPTION
When (for example) no clean is done before running the checksum calculation the main checksum file (created by the ChecksumTask) will append the checksum to the file, and not overwrite it with the proper checksum. Thus the checksum will build up and not be equal even though it should.

There are two commits:

- One that contains a test case showing the problem
- One that corrects the problem 